### PR TITLE
CHORE: Move `wait` to another place

### DIFF
--- a/src/e2e/core/mixin/ui/base.py
+++ b/src/e2e/core/mixin/ui/base.py
@@ -1,5 +1,3 @@
-import time
-
 from e2e.core.ui import Button, Element, ElementCallable, TextField
 
 from .wd import WDMixin
@@ -21,7 +19,3 @@ class BaseUIMixin(WDMixin):
     @property
     def textfield(self) -> ElementCallable[TextField]:
         return ElementCallable(wd=self.wd, dtype=TextField)
-
-    def wait(self, seconds: float = 1):
-        self.logger.debug(f'Wait for {seconds}s')
-        time.sleep(seconds)

--- a/src/e2e/core/mixin/ui/wd.py
+++ b/src/e2e/core/mixin/ui/wd.py
@@ -1,3 +1,4 @@
+import time
 import typing as t
 from functools import cached_property
 
@@ -7,6 +8,10 @@ from e2e.core.mixin.logger import LoggerMixin
 
 class WDMixin(LoggerMixin):
     wd: WD
+
+    def wait(self, seconds: float = 1):
+        self.logger.debug(f'Wait for {seconds}s')
+        time.sleep(seconds)
 
     @cached_property
     def window_size(self) -> t.Tuple[float, float]:


### PR DESCRIPTION
This way, we can access the wait in `Tester`. 
`tester.wait(3)` sounds more natural than `tester.ui.wait(3)`