### PR TITLE
FEAT: Support parallelism with pytest-xdist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "retry",
     "Appium-Python-Client",
     "pytest",
+    "pytest-xdist",
     "click",
     "seeeye>=0.0.5",
 ]
@@ -40,6 +41,7 @@ dev = [
     "twine",
     "pytest",
     "pytest-cov",
+    "pytest-html",
     "sphinx_rtd_theme",
 ]
 
@@ -57,4 +59,4 @@ namespaces = true
 skip_string_normalization = true
 
 [tool.pytest.ini_options]
-addopts = "-s -v --cov=. --cov-report=xml"
+addopts = "-s -v --cov=. --cov-report=xml --log-file=.artifacts/latest/pytest.log --html=.artifacts/latest/report.html"

--- a/src/e2e/fixtures/__init__.py
+++ b/src/e2e/fixtures/__init__.py
@@ -1,5 +1,6 @@
 from .artifacts import *
 from .core import *
 from .diagnostic import *
+from .parallel import *
 from .simulator import *
 from .tester import *

--- a/src/e2e/fixtures/parallel.py
+++ b/src/e2e/fixtures/parallel.py
@@ -1,0 +1,17 @@
+import re
+import typing as t
+
+import pytest
+
+
+@pytest.fixture(scope='session')
+def parallel_config(parallel_worker_id) -> t.Dict[str, t.Any]:
+    if parallel_worker_id is None:
+        return {}
+    return {'parallel_worker_id': parallel_worker_id}
+
+
+@pytest.fixture(scope='session')
+def parallel_worker_id(worker_id):
+    if m := re.match(r'\D*(\d+)', worker_id):
+        return int(m.group(1))

--- a/src/e2e/fixtures/simulator.py
+++ b/src/e2e/fixtures/simulator.py
@@ -10,9 +10,15 @@ from e2e.core.utils import WDUtils
 
 
 @pytest.fixture
-def prepare_simulator(merged_capabilities: t.Dict[str, t.Any]):
+def prepare_simulator(
+    merged_capabilities: t.Dict[str, t.Any],
+    parallel_worker_id: t.Optional[int],
+) -> str:
     device = WDUtils.device_from_caps(merged_capabilities)
     if not device:
-        with Simulator(name='E2E') as simulator:
+        name = 'E2E' if parallel_worker_id is None else f'E2E-{parallel_worker_id + 1}'
+        with Simulator(name=name) as simulator:
             device = simulator.name
+            merged_capabilities['deviceName'] = device
     logger.debug(f'Using device: {device}')
+    return device


### PR DESCRIPTION
Run parallel tests with the `-n` argument (offered by pytest-xdist)

```
pytest -n 2 tests/e2e/test_settings.py
```

![parallel_e2e](https://github.com/trinhngocthuyen/e2e-mobile/assets/8844044/50962089-bf65-47a7-aaee-a5985f283c40)
