### PR TITLE
Use prebuilt app for e2e build demo

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -52,7 +52,7 @@ The given test runs against the Wikipedia app.
 
     Prior to running the above test, you might want to build the `Wikipedia iOS project <https://github.com/wikimedia/wikipedia-ios>`_.
     Simply run: ``make demo.build`` or ``e2e demo build``.
-    The app will be placed under ``tmp/apps/example.app``
+    The app will be placed under ``tmp/apps/Wikipedia.zip``
 
 **Step 5: Format changes**
 

--- a/docs/getting_started/inspecting_elements.rst
+++ b/docs/getting_started/inspecting_elements.rst
@@ -62,7 +62,7 @@ The minimal capabilities include ``app``, ``automationName`` and ``platformName`
 .. code-block:: json
 
     {
-        "app": "/Users/thuyen/projects/e2e-mobile/tmp/apps/example.app",
+        "app": "/Users/thuyen/projects/e2e-mobile/tmp/apps/Wikipedia.zip",
         "automationName": "xcuitest",
         "platformName": "iOS"
     }

--- a/docs/getting_started/quick_start.rst
+++ b/docs/getting_started/quick_start.rst
@@ -38,7 +38,7 @@ No worries, you simply need to run:
 
     $ e2e demo build
 
-This command clones the `Wikipedia iOS project <https://github.com/wikimedia/wikipedia-ios>`_, builds it, and place the ``.app`` bundle under ``tmp/apps/example.app``.
+This command clones the `Wikipedia iOS project <https://github.com/wikimedia/wikipedia-ios>`_, builds it, and place the ``.app`` bundle under ``tmp/apps/Wikipedia.zip``.
 
 .. note::
 

--- a/docs/getting_started/writing_your_first_test.rst
+++ b/docs/getting_started/writing_your_first_test.rst
@@ -3,7 +3,7 @@ Writing Your First Test
 
 Let's create a simple test.
 
-For the sake of demonstration, we're going to use the Wikipedia iOS app for testing. In case you did not have the app under ``tmp/apps/example.app``, you can simply run ``e2e demo build``. This command clones the project and builds the app for you.
+For the sake of demonstration, we're going to use the Wikipedia iOS app for testing. In case you did not have the app under ``tmp/apps/Wikipedia.zip``, you can simply run ``e2e demo build``. This command clones the project and builds the app for you.
 
 Let's say we are testing the Settings screen in the app.
 

--- a/src/e2e/_templates/tests/e2e/conftest.py.template
+++ b/src/e2e/_templates/tests/e2e/conftest.py.template
@@ -30,5 +30,6 @@ def setup_wd_options():
 @pytest.fixture
 def capabilities():
     return {
-        'app': 'tmp/apps/example.app',  # TODO: Update the path to the app here
+        'app': 'tmp/apps/Wikipedia.zip',  # TODO: Update the path to the app here
+        'bundleId': 'org.wikimedia.wikipedia',
     }

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -30,5 +30,6 @@ def setup_wd_options():
 @pytest.fixture
 def capabilities():
     return {
-        'app': 'tmp/apps/example.app',  # TODO: Update the path to the app here
+        'app': 'tmp/apps/Wikipedia.zip',  # TODO: Update the path to the app here
+        'bundleId': 'org.wikimedia.wikipedia',
     }


### PR DESCRIPTION
Add an option to download prebuilt Wikipedia.zip (from https://github.com/trinhngocthuyen/prebuilt/blob/main/wikipedia/Wikipedia.zip)